### PR TITLE
Beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.bak
+Attempts.txt

--- a/README.txt
+++ b/README.txt
@@ -16,7 +16,7 @@ Feel free to open RogueChallenges.py and edit the parameters near the top if you
 This mod adds many additonal archmage trials. All of them limit your spells and skills similarly to the RogueLikeMode mod. Each successive challenge have all the modifiers of all the previous challenges, similarly to Ascensions in Slay the Spire, Covenent in Monster Train, Eclipse in Risk of Rain 2, etc. All of them are succinctly summarized on the Archmage Trials screen ingame, but if you want to know all the little details then here they are.
 
 ----- Roguelike Mode:
---- Start with 14 spells and 7 skills. Gain 2 new spells and 1 new skill after each completed level.
+--- Start with 14 spells and 7 skills. Gain 2 new spells and 1 new skill after each completed realm.
 
 - You always start with two spells that cost 1 SP.
 - Unlike previous versions, you get the new spells and skill immediately when you defeat all the enemies, so you can see what new things you got before entering a new level.

--- a/README.txt
+++ b/README.txt
@@ -82,9 +82,10 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - Be very careful about realms with multiple war banners as the monster count can really get out of hand quickly.
 
 ----- Rogue Challenge 9:
---- Healing potions restore 65% of your missing HP, and you restore 35% less HP with all other healing effects.
+--- Healing potions restore 60% of your missing HP or 40% of your max HP, whichever is greater.
 
 - You still get the most value from your healing potions by waiting until you have very low HP remaining.
+- If you want to return to full HP for safety, you can just use two healing potions.
 
 ----- Rogue Challenge 10:
 --- Each point of SH on monsters has a 30% chance of granting +1 SH.

--- a/README.txt
+++ b/README.txt
@@ -50,7 +50,7 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - Elite monsters are variant monsters or monsters that are one level higher than the maximum "normal" monster level that can appear in a rift.
 - Realm 9 onward has 0-2 extra elite monsters, and every 2 realms there is an additional elite monster, until it maxes at 5-7
 - Elite gates have higher HP than normal gates and spawn these more difficult additional monsters.
-- Starting at realm 9, for the rest of the game all realmss have one normal gate replaced by an elite gate.
+- Starting at realm 9, for the rest of the game all realms have one normal gate replaced by an elite gate.
 - This replacement is increased to two gates at realm 15, and increased to three gates at realm 22.
 - I recommend avoiding rifts with three Bone Shambler Megalith gates spread out over the map.
 

--- a/README.txt
+++ b/README.txt
@@ -19,16 +19,16 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 --- Start with 14 spells and 7 skills. Gain 2 new spells and 1 new skill after each completed realm.
 
 - You always start with two spells that cost 1 SP.
-- Unlike previous versions, you get the new spells and skill immediately when you defeat all the enemies, so you can see what new things you got before entering a new level.
+- Unlike previous versions, you get the new spells and skill immediately when you defeat all the enemies, so you can see what new things you got before entering a new realm.
 - There is no discount on skills, by default.
-- Again, you can open RogueChallenges.py and edit the parameters near the top if you want to change how many spells and skills you start with, or how many you gain after each level, or even bring back the skill discount. You can even disable the spell and skill restrictions entirely if you want to try the following trials without them.
+- Again, you can open RogueChallenges.py and edit the parameters near the top if you want to change how many spells and skills you start with, or how many you gain after each realm, or even bring back the skill discount. You can even disable the spell and skill restrictions entirely if you want to try the following trials without them.
 
 ----- Rogue Challenge 1:
 --- Each realm has additional monster generators.
 
-- Level 2 onward has one additional gate.
-- Level 8 onward has another additional gate.
-- Level 15 onward has yet another gate.
+- Realm 2 onward has one additional gate.
+- Realm 8 onward has another additional gate.
+- Realm 15 onward has yet another gate.
 
 ----- Rogue Challenge 2:
 --- All realms have more monsters. Realms with relatively easier monsters have many more of them.
@@ -50,8 +50,8 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - Elite monsters are variant monsters or monsters that are one level higher than the maximum "normal" monster level that can appear in a rift.
 - Realm 9 onward has 0-2 extra elite monsters, and every 2 realms there is an additional elite monster, until it maxes at 5-7
 - Elite gates have higher HP than normal gates and spawn these more difficult additional monsters.
-- Starting at level 9, for the rest of the game all levels have one normal gate replaced by an elite gate.
-- This replacement is increased to two gates at level 15, and increased to three gates at level 22.
+- Starting at realm 9, for the rest of the game all realmss have one normal gate replaced by an elite gate.
+- This replacement is increased to two gates at realm 15, and increased to three gates at realm 22.
 - I recommend avoiding rifts with three Bone Shambler Megalith gates spread out over the map.
 
 ----- Rogue Challenge 5:

--- a/README.txt
+++ b/README.txt
@@ -93,6 +93,7 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - Enemies with SH could end up with no additional SH. Or they could end up with double SH, if they are very lucky.
 - As an example, a glass golem normally has 2 SH. With this challenge, each different glass golem has a 49% chance of 2 SH, a 42% chance of 3 SH, and a 9% chance of 4 SH.
 - This can increase SH above 20. I'm really sorry about the glass butterflies.
+- After realm 1 this effect applies to gates at a 2% chance, increasing by 2% each realm until it reaches 30%
 
 ----- Rogue Challenge 11:
 --- All enemy monsters have cooldowns reduced by 30%, rounded up; enemy wizards appear after realm 6.

--- a/README.txt
+++ b/README.txt
@@ -24,40 +24,41 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - Again, you can open RogueChallenges.py and edit the parameters near the top if you want to change how many spells and skills you start with, or how many you gain after each level, or even bring back the skill discount. You can even disable the spell and skill restrictions entirely if you want to try the following trials without them.
 
 ----- Rogue Challenge 1:
---- Each level has additional monster generators.
+--- Each realm has additional monster generators.
 
 - Level 2 onward has one additional gate.
 - Level 8 onward has another additional gate.
 - Level 15 onward has yet another gate.
 
 ----- Rogue Challenge 2:
---- All levels have more monsters. Areas with relatively easier monsters have many more of them.
+--- All realms have more monsters. Realms with relatively easier monsters have many more of them.
 
-- Usually all levels have 5-20 "normal" monsters.
+- Usually all realms have 5-20 "normal" monsters.
 - If these monsters are at the maximum possible level relative to the player's progress, the amount is increased to 10-20.
 - If these monsters are instead at the minimum possible level, the amount is increased to 20-26.
 - The final amount scales proporionally if the monsters have level in between the maximum or minimum.
 
 ----- Rogue Challenge 3:
---- All enemy units have 15% more damage.
+--- All enemy monsters have 15% more damage.
 
 - This only affects the damage from spells. Passive effects like Efreet damage aura remain the same.
 - The damage is always rounded to the nearest whole number. A spell with 3 damage will still remain at 3, but a spell with 4 damage will be increased to 5.
 
 ----- Rogue Challenge 4:
---- Each level beyond level 12 has 5-7 extra elite monsters; later levels have elite gates
+--- Realms 9 and beyond have extra elite monsters and elite gates
 
-- Elite monsters are random non-variant monsters that are one level higher than the maximum "normal" monster level that can appear in a rift.
+- Elite monsters are variant monsters or monsters that are one level higher than the maximum "normal" monster level that can appear in a rift.
+- Realm 9 onward has 0-2 extra elite monsters, and every 2 realms there is an additional elite monster, until it maxes at 5-7
 - Elite gates have higher HP than normal gates and spawn these more difficult additional monsters.
-- Starting at level 15, for the rest of the game all levels have one normal gate replaced by an elite gate.
-- This replacement is increased to two gates at level 18, and increased to three gates at level 22.
+- Starting at level 9, for the rest of the game all levels have one normal gate replaced by an elite gate.
+- This replacement is increased to two gates at level 15, and increased to three gates at level 22.
 - I recommend avoiding rifts with three Bone Shambler Megalith gates spread out over the map.
 
 ----- Rogue Challenge 5:
---- Less consumable items and mana potions in each level.
+--- Less consumable items and mana potions in each realm.
 
-- Normally after level 4, each rift has a 1/6 chance of containing two mana potions and a 2/6 chance of one mana potion. This is changed to a 1/10 chance of two mana potions and a 4/10 chance of one mana potion. The chance of getting no mana potions is unchanged.
-- Normally after level 2, each rift has a 1/8 chance of three consumables, a 1/8 chance of two consumables, and a 2/8 chance of one consumable. This is changed to a 1/8 chance of two consumables and a 3/8 chance of one consumable. The chance of getting no consumables is unchanged.
+- Normally after realm 4, each realm has a 1/6 chance of containing two mana potions and a 2/6 chance of one mana potion. This is changed to a 1/10 chance of two mana potions and a 4/10 chance of one mana potion. The chance of getting no mana potions is unchanged.
+- Normally after realm 2, each realm has a 1/8 chance of three consumables, a 1/8 chance of two consumables, and a 2/8 chance of one consumable. This is changed to a 1/8 chance of two consumables and a 3/8 chance of one consumable. The chance of getting no consumables is unchanged.
 
 ----- Rogue Challenge 6:
 --- Mordred creates more difficult realms, and gains a shield every 2 turns, up to max of 7.
@@ -94,7 +95,7 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - This can increase SH above 20. I'm really sorry about the glass butterflies.
 
 ----- Rogue Challenge 11:
---- All enemy monsters have cooldowns reduced by 30%, rounded up; enemy wizards appear after level 6.
+--- All enemy monsters have cooldowns reduced by 30%, rounded up; enemy wizards appear after realm 6.
 
 - The smallest cooldown that is affected is 4, which is changed to 3 by this challenge.
 - The wizards that can appear are the same ones that appear in Wizard Warlords trial.
@@ -106,9 +107,9 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - Again the damage only affects spells, and rounds to the nearest whole number.
 
 ----- Rogue Challenge 13:
---- 1 less SP in every third level.
+--- 1 less SP in every third realm.
 
-- Affects levels 3, 6, 9, 12, etc.
+- Affects realms 3, 6, 9, 12, etc.
 - I put this challenge last since its has the greatest difficulty/interesting ratio.
 
 ---------------------------------------------------------------------------------------------------

--- a/README.txt
+++ b/README.txt
@@ -27,8 +27,7 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 --- Each realm has additional monster generators.
 
 - Realm 2 onward has one additional gate.
-- Realm 8 onward has another additional gate.
-- Realm 15 onward has yet another gate.
+- Realm 15 onward has another additional gate.
 
 ----- Rogue Challenge 2:
 --- All realms have more monsters. Realms with relatively easier monsters have many more of them.

--- a/README.txt
+++ b/README.txt
@@ -109,10 +109,18 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - Again the damage only affects spells, and rounds to the nearest whole number.
 
 ----- Rogue Challenge 13:
---- 1 less SP in every third realm.
+--- Every 4 realms, there's one less Memory Orb to pick up.
 
-- Affects realms 3, 6, 9, 12, etc.
+- Affects realms 4, 8, 12, 16, etc.
 - I put this challenge last since its has the greatest difficulty/interesting ratio.
+
+----- Unfair Challenge:
+--- All nerfs I've made to Rogue Challenges are reverted. This is REALLY HARD.
+
+- Realm 8 onward has an additional gate.
+- Wizards have a 100% chance of appearing in realm 7 onward.
+- Instead of every 4 realms, there's one less Memory Orb every 3 realms.
+- Good luck. You'll need it.
 
 ---------------------------------------------------------------------------------------------------
 

--- a/README.txt
+++ b/README.txt
@@ -96,9 +96,10 @@ This mod adds many additonal archmage trials. All of them limit your spells and 
 - After realm 1 this effect applies to gates at a 2% chance, increasing by 2% each realm until it reaches 30%
 
 ----- Rogue Challenge 11:
---- All enemy monsters have cooldowns reduced by 30%, rounded up; enemy wizards appear after realm 6.
+--- All enemy monsters have cooldowns reduced by 30%, rounded up; enemy wizards may appear in realm 7 or later
 
 - The smallest cooldown that is affected is 4, which is changed to 3 by this challenge.
+- There's a 10% chance of an wizard appearing in realm 7, and the chance increases by 10% on each successive realm.
 - The wizards that can appear are the same ones that appear in Wizard Warlords trial.
 
 ----- Rogue Challenge 12:

--- a/RogueChallenges.py
+++ b/RogueChallenges.py
@@ -41,8 +41,8 @@ try:
 except ImportError:
     ANTI_POISON = False
 
-TEST_CHEATY = True
-TEST_ELITE_GATES = True
+TEST_CHEATY = False
+TEST_ELITE_GATES = False
 TEST_SHIELD_GATES = False
 TEST_MORDRED = False
 TEST_SLIMES = False

--- a/RogueChallenges.py
+++ b/RogueChallenges.py
@@ -204,17 +204,19 @@ class RogueLikeModeBuff(Level.Buff):
             
 class MoreGates(Mutator):
     
-    def __init__(self):
+    def __init__(self, realm_list=[2,15]):
         Mutator.__init__(self)
+        self.realm_list = realm_list
         self.description = "Each realm has additional monster generators"
 
     def on_levelgen_pre(self, levelgen):
         #dont add gates to Mordred's place
-        if levelgen.difficulty == 1 or levelgen.difficulty == Level.LAST_LEVEL:
+        if levelgen.difficulty == Level.LAST_LEVEL:
             return
         
-        moreGateNum = 1 if levelgen.difficulty < 15 else 2
-        levelgen.num_generators += moreGateNum
+        for realm_num in self.realm_list:
+            if levelgen.difficulty >= realm_num:
+                levelgen.num_generators += 1
              
 class MonsterHordes(Mutator):
 
@@ -810,7 +812,7 @@ def addCumulativeTrial(newMutator):
         (7, 8), # 24
 """
    
-addCumulativeTrial(MoreGates())
+addCumulativeTrial(MoreGates(realm_list=[2,15]))
 addCumulativeTrial(MonsterHordes(10,20,10,6))
 addCumulativeTrial(EnemyDamageMult(1.15)) 
 addCumulativeTrial(EliteSpawnsAndGates(9,2,6))

--- a/RogueChallenges.py
+++ b/RogueChallenges.py
@@ -213,7 +213,7 @@ class MoreGates(Mutator):
         if levelgen.difficulty == 1 or levelgen.difficulty == Level.LAST_LEVEL:
             return
         
-        moreGateNum = 1 if levelgen.difficulty < 8 else 2 if levelgen.difficulty < 15 else 3
+        moreGateNum = 1 if levelgen.difficulty < 15 else 2
         levelgen.num_generators += moreGateNum
              
 class MonsterHordes(Mutator):
@@ -794,7 +794,7 @@ def addCumulativeTrial(newMutator):
         (2, 3), # 5 - generators increase
         (2, 4), # 6 - chance of unique
         (2, 4), # 7 - (guaranteed wizard)
-        (2, 4), # 8 - (+1 gate)
+        (2, 4), # 8
         (2, 4), # 9 - more elites (slightly more, and change one gate to an elite type )
         (3, 4), # 10 - generators increase
         (3, 5), # 11 - guaranteed unique, harder uniques

--- a/RogueChallenges.py
+++ b/RogueChallenges.py
@@ -85,13 +85,44 @@ def modify_class(cls):
                     self.draw_string(line, self.screen, cur_x, cur_y)
                     cur_y += self.linesize
                     
+        def get_anim(self, unit, forced_name=None):
+
+            # Find the asset name
+            if forced_name:
+                asset = ["char", forced_name]
+            else:
+                asset = get_unit_asset(unit)
+
+            # Determine lair colors for lairs
+            lair_colors = None
+            if unit.is_lair:
+                example_monster = unit.buffs[0].example_monster
+                example_sprite_name = example_monster.get_asset_name()
+                example_sprite = self.get_sprite_sheet(get_unit_asset(example_monster))
+                lair_colors = example_sprite.get_lair_colors()
+                
+            # modify colors of elite gates
+            if lair_colors is not None and unit.description == "EliteGate":
+                new_colors = []
+                for i in range(len(lair_colors)):
+                    color = lair_colors[i]
+                    colorR = min(255, color[0] + 70)
+                    colorG = min(255, color[1] + 70)
+                    colorB = min(255, color[2] + 70)
+                    new_colors.append(tuple([colorR, colorG, colorB]))
+                    
+                lair_colors = tuple(new_colors)
+
+            sprite = self.get_sprite_sheet(asset, lair_colors=lair_colors)
+
+            return UnitSprite(unit, sprite, view=self)
+                    
     for func_name, func in [(key, value) for key, value in locals().items() if callable(value)]:
         if hasattr(cls, func_name):
             setattr(cls, func_name, func)
 
-if not BUG_FIXED:
-    curr_module = sys.modules[__name__]
-    curr_module.modify_class(PyGameView)
+curr_module = sys.modules[__name__]
+curr_module.modify_class(PyGameView)
 
 
 class RogueLikeMode(Mutator):

--- a/RogueChallenges.py
+++ b/RogueChallenges.py
@@ -106,7 +106,7 @@ class RogueLikeMode(Mutator):
         self.num_newspells = math.floor(num_newspells)
         self.num_newskills = math.floor(num_newskills)
         self.discount = math.floor(discount)
-        self.description = "Start with %d spells and %d skills\nGain %d new spells and %d new skills after each completed level" % (self.numspells, self.numskills, self.num_newspells, self.num_newskills)
+        self.description = "Start with %d spells and %d skills\nGain %d new spells and %d new skills after each completed realm" % (self.numspells, self.numskills, self.num_newspells, self.num_newskills)
         if self.discount > 0:
             self.description += "\nSkills are %d SP cheaper" % self.discount
         self.otherspells = None

--- a/RogueChallenges.py
+++ b/RogueChallenges.py
@@ -670,7 +670,10 @@ class WizardAndCooldowns(Mutator):
         if not evt.unit.ever_spawned:
             self.modify_unit(evt.unit)
             
-    def on_levelgen_pre(self, levelgen):            
+    def on_levelgen_pre(self, levelgen):
+        if levelgen.difficulty == Level.LAST_LEVEL:
+            return
+            
         if TEST_WIZARD_COOLDOWNS:
             wizard = FrostfireWizard()
             wizard.is_boss = True
@@ -831,7 +834,7 @@ def addCumulativeTrial(newMutator):
         (1, 3), # 4 - more elites
         (2, 3), # 5 - generators increase
         (2, 4), # 6 - chance of unique
-        (2, 4), # 7 - (guaranteed wizard)
+        (2, 4), # 7 - (10% wizard)
         (2, 4), # 8
         (2, 4), # 9 - more elites (slightly more, and change one gate to an elite type )
         (3, 4), # 10 - generators increase

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,7 @@
++ RC 1 no longer has +1 gate on realm 8
++ RC 4 chosen elites are high level monsters or variants that were present in the level before, if possible
++ RC 9 remove heal reduction passive, healing potions heal 60% of missing hp or 40% of max hp, whichever is greater
++ RC 10 past level 2, gates also can have additional shields (2% higher chance per realm)
++ RC 11 guaranteed wizard instead is a 10% chance of wizard, +10% more chance on each futher level
+- RC 13 every 3rd level has 1 less SP -> every 4th
+- new "Unfair Challenge" that undoes the RC 1, 11, 13 nerfs


### PR DESCRIPTION
+ RC 1 no longer has +1 gate on realm 8
+ RC 4 chosen elites are high level monsters or variants that were present in the level before, if possible
+ RC 9 remove heal reduction passive, healing potions heal 60% of missing hp or 35% of max hp, whichever is greater
+ RC 10 past level 2, gates also can have additional shields (2% higher chance per realm)
+ RC 11 guaranteed wizard instead is a 10% chance of wizard, +10% more chance on each futher level
- RC 13 every 3rd level has 1 less SP -> every 4th
- new "Unfair Challenge" that undoes the RC 1, 11, 13 nerfs